### PR TITLE
Check xdrmaxsize tag in Decoder.decodeUnion

### DIFF
--- a/xdr3/encode_test.go
+++ b/xdr3/encode_test.go
@@ -364,7 +364,7 @@ func TestMarshal(t *testing.T) {
 
 	// bad enum
 	w = newFixedWriter(4)
-	_, err = Marshal(w, AnEnum(2))
+	_, err = Marshal(w, AnEnum(3))
 	rv = w.Bytes()
 
 	if err == nil {
@@ -413,7 +413,7 @@ func TestMarshal(t *testing.T) {
 	// Union encoding
 	// void arm
 	var u aUnion
-	u.Type = AnEnum(1)
+	u.Type = AnEnum(2)
 	w = newFixedWriter(4)
 	n, err = Marshal(w, u)
 	rv = w.Bytes()
@@ -426,7 +426,7 @@ func TestMarshal(t *testing.T) {
 		t.Errorf("union encode: unexpected len - got: %v want: 4\n", n)
 	}
 
-	if !reflect.DeepEqual([]byte{0x00, 0x00, 0x00, 0x01}, rv) {
+	if !reflect.DeepEqual([]byte{0x00, 0x00, 0x00, 0x02}, rv) {
 		t.Errorf("union encode: unexpected result - got: %v", rv)
 	}
 


### PR DESCRIPTION
decodeUnion method of Decoder wasn't checking for tag xdrmaxsize in the
fields of an union. Attacker could exploit this by creating an union
with a very long string (large XDR length value) and passing it to
Decoder. By doing this attacker could allocate a lot of memory and crash
an app that's using go-xdr.

This commit fixes this by checking for xdrmaxsize tag in decodeUnion.