### PR TITLE
Prevent invalid enums from being decoded into unions

### DIFF
--- a/xdr3/decode.go
+++ b/xdr3/decode.go
@@ -507,6 +507,16 @@ func (d *Decoder) decodeUnion(v reflect.Value) (int, error) {
 	}
 
 	vs := v.FieldByName(u.SwitchFieldName())
+
+	// ensure the switch field is a valid enum value for the union, if possible
+	enum, ok := vs.Interface().(Enum)
+
+	if ok && !enum.ValidEnum(i) {
+		msg := fmt.Sprintf("switch '%d' is not valid enum value for union", i)
+		err := unmarshalError("decode", ErrBadUnionSwitch, msg, nil, nil)
+		return n, err
+	}
+
 	vs.SetInt(int64(i))
 
 	arm, ok := u.ArmForSwitch(i)


### PR DESCRIPTION
This PR fixes a bug uncovered by fuzzing the stellar xdr codebase:  When reading a union off the wire the enum value used for the union switch is not checked for validity using the `ValidEnum` method.  Normally, an error is still triggered because `ArmForSwitch` will error, except in cases where the union has a default case.  Prior to this change, the union would be considered valid and decoding would succeed.