### PR TITLE
allow arm switches to be uint

### DIFF
--- a/xdr3/decode.go
+++ b/xdr3/decode.go
@@ -533,7 +533,13 @@ func (d *Decoder) decodeUnion(v reflect.Value) (int, error) {
 		return n, err
 	}
 
-	vs.SetInt(int64(i))
+	kind := vs.Kind()
+	if kind == reflect.Uint || kind == reflect.Uint8 || kind == reflect.Uint16 ||
+		kind == reflect.Uint32 || kind == reflect.Uint64 {
+		vs.SetUint(uint64(i))
+	} else {
+		vs.SetInt(int64(i))
+	}
 
 	arm, ok := u.ArmForSwitch(i)
 

--- a/xdr3/encode.go
+++ b/xdr3/encode.go
@@ -448,7 +448,14 @@ func (enc *Encoder) encodeUnion(v reflect.Value) (int, error) {
 		return n, err
 	}
 
-	sw := int32(vs.Int())
+	kind := vs.Kind()
+	var sw int32
+	if kind == reflect.Uint || kind == reflect.Uint8 || kind == reflect.Uint16 ||
+		kind == reflect.Uint32 || kind == reflect.Uint64 {
+		sw = int32(vs.Uint())
+	} else {
+		sw = int32(vs.Int())
+	}
 	arm, ok := u.ArmForSwitch(sw)
 
 	// void arm, we're done


### PR DESCRIPTION
`stellar/go/xdr/xdr_generated.go` has `AuthenticatedMessage` with an `uint32` selector, this breaks xdr. This change seems to make it work.