### PR TITLE
Fix incorrect decoding of array when input contains more elements

### DIFF
--- a/xdr3/decode.go
+++ b/xdr3/decode.go
@@ -485,9 +485,7 @@ func (d *Decoder) decodeArray(v reflect.Value, ignoreOpaque bool, maxSize int) (
 	if v.Cap() < sliceLen {
 		v.Set(reflect.MakeSlice(v.Type(), sliceLen, sliceLen))
 	}
-	if v.Len() < sliceLen {
-		v.SetLen(sliceLen)
-	}
+	v.SetLen(sliceLen)
 
 	// Treat []byte (byte is alias for uint8) as opaque data unless ignored.
 	if !ignoreOpaque && v.Type().Elem().Kind() == reflect.Uint8 {

--- a/xdr3/decode_test.go
+++ b/xdr3/decode_test.go
@@ -525,7 +525,6 @@ func TestUnmarshal(t *testing.T) {
 	if err == nil {
 		t.Errorf("union decode: expected error, got nil")
 	}
-
 }
 
 // decodeFunc is used to identify which public function of the Decoder object
@@ -799,6 +798,20 @@ func TestUnmarshalCorners(t *testing.T) {
 		if !reflect.DeepEqual(cappedSlice, expectedVal) {
 			t.Errorf("%s: unexpected result - got: %v want: %v\n",
 				testName, cappedSlice, expectedVal)
+		}
+	}
+
+	// Ensure decode to a slice retuns expected number of elements
+	testName = "Unmarshal to oversized slice"
+	oversizedSlice := make([]bool, 2, 2)
+	expectedN = 8
+	expectedErr = nil
+	expectedVal = []bool{true}
+	n, err = Unmarshal(bytes.NewReader(buf), &oversizedSlice)
+	if testExpectedURet(t, testName, n, expectedN, err, expectedErr) {
+		if !reflect.DeepEqual(oversizedSlice, expectedVal) {
+			t.Errorf("%s: unexpected result - got: %v want: %v\n",
+				testName, oversizedSlice, expectedVal)
 		}
 	}
 


### PR DESCRIPTION
Upstream issue: stellar/go#374.

Originally planned to work around it on stellar/go side (with stellar/go#597), but looks like the actual fix belongs here.